### PR TITLE
Migrate theme toggle to server

### DIFF
--- a/src/app/actions/theme.ts
+++ b/src/app/actions/theme.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+export type Theme = "light" | "dark";
+
+export async function setTheme(theme: Theme): Promise<void> {
+    const cookieStore = await cookies();
+    cookieStore.set("theme", theme, {
+        path: "/",
+        httpOnly: false,
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24 * 365, // 1 year
+        secure: process.env.NODE_ENV === "production",
+    });
+}
+
+export async function toggleTheme(): Promise<Theme> {
+    const cookieStore = await cookies();
+    const current = cookieStore.get("theme")?.value as Theme | undefined;
+    const next: Theme = current === "dark" ? "light" : "dark";
+    await setTheme(next);
+    return next;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { cookies } from "next/headers";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -17,13 +18,17 @@ export const metadata: Metadata = {
     description: "Simple timesheeting app",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
     children,
 }: Readonly<{
     children: React.ReactNode;
 }>) {
+    const cookieStore = await cookies();
+    const theme = cookieStore.get("theme")?.value;
+    const isDark = theme === "dark";
+
     return (
-        <html lang="en">
+        <html lang="en" className={isDark ? "dark" : ""} suppressHydrationWarning>
             <body
                 className={`${geistSans.variable} ${geistMono.variable} antialiased`}
             >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type React from "react";
+import React from "react";
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { format, addDays, subDays, addWeeks, isWeekend } from "date-fns";
@@ -87,7 +87,6 @@ export default function TimeTracker() {
     const titleInputRef = useRef<HTMLInputElement>(null);
 
     const [templates, setTemplates] = useState<TaskTemplate[]>([]);
-    const [theme, setTheme] = useState<"light" | "dark">("light");
     const [repeatCount, setRepeatCount] = useState<number>(0);
     const [repeatEvery, setRepeatEvery] = useState<"day" | "week">("day");
     const [weekdaysOnly, setWeekdaysOnly] = useState<boolean>(false);
@@ -129,24 +128,7 @@ export default function TimeTracker() {
         );
     }, [templates]);
 
-    // Theme initialization
-    useEffect(() => {
-        const saved = localStorage.getItem("theme");
-        const prefersDark =
-            saved === "dark" ||
-            (!saved &&
-                window.matchMedia &&
-                window.matchMedia("(prefers-color-scheme: dark)").matches);
-        document.documentElement.classList.toggle("dark", !!prefersDark);
-        setTheme(prefersDark ? "dark" : "light");
-    }, []);
-
-    const toggleTheme = () => {
-        const next = theme === "dark" ? "light" : "dark";
-        setTheme(next);
-        localStorage.setItem("theme", next);
-        document.documentElement.classList.toggle("dark", next === "dark");
-    };
+    // Theme is managed on the server via cookies; client code avoids local state
 
     // Filter tasks for selected date
     const filteredTasks = tasks.filter(
@@ -878,10 +860,8 @@ export default function TimeTracker() {
         <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
             <Header
                 selectedDate={selectedDate}
-                theme={theme}
                 onPreviousDay={handlePreviousDay}
                 onNextDay={handleNextDay}
-                onToggleTheme={toggleTheme}
             />
 
             {/* Main Content with top padding for fixed header and right margin for sidebar */}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,25 +1,33 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight, Sun, Moon } from "lucide-react";
 import { format } from "date-fns";
+import { toggleTheme } from "@/app/actions/theme";
 
 interface HeaderProps {
     selectedDate: Date;
-    theme: "light" | "dark";
     onPreviousDay: () => void;
     onNextDay: () => void;
-    onToggleTheme: () => void;
 }
 
-export function Header({
-    selectedDate,
-    theme,
-    onPreviousDay,
-    onNextDay,
-    onToggleTheme,
-}: HeaderProps) {
+export function Header({ selectedDate, onPreviousDay, onNextDay }: HeaderProps) {
+    const [isDark, setIsDark] = useState(false);
+
+    useEffect(() => {
+        const html = document.documentElement;
+        setIsDark(html.classList.contains("dark"));
+    }, []);
+
+    const handleToggleTheme = async () => {
+        const next = !isDark;
+        // Persist on server via cookie
+        await toggleTheme();
+        // Immediate UI update without full refresh
+        document.documentElement.classList.toggle("dark", next);
+        setIsDark(next);
+    };
     return (
         <div className="fixed top-0 left-0 right-0 z-[1100] bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur supports-[backdrop-filter]:bg-gray-50/80 dark:supports-[backdrop-filter]:bg-gray-900/80 border-b border-gray-200 dark:border-gray-700 shadow-sm">
             <div className="flex items-center justify-between px-4 py-3">
@@ -53,9 +61,9 @@ export function Header({
                         variant="ghost"
                         size="icon"
                         aria-label="Toggle theme"
-                        onClick={onToggleTheme}
+                        onClick={handleToggleTheme}
                     >
-                        {theme === "dark" ? (
+                        {isDark ? (
                             <Moon className="h-5 w-5 transition-transform duration-300 rotate-0" />
                         ) : (
                             <Sun className="h-5 w-5 transition-transform duration-300 rotate-180" />

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { toggleTheme } from "@/app/actions/theme";
 
 interface UseKeyboardShortcutsProps {
     onPreviousDay: () => void;
@@ -64,16 +65,13 @@ export function useKeyboardShortcuts({
                     break;
                 case "\\":
                     e.preventDefault();
-                    // toggle theme by toggling data-theme or class
-                    const html = document.documentElement;
-                    const isDark = html.classList.contains("dark");
-                    if (isDark) {
-                        html.classList.remove("dark");
-                        localStorage.setItem("theme", "light");
-                    } else {
-                        html.classList.add("dark");
-                        localStorage.setItem("theme", "dark");
-                    }
+                    // Persist theme on server and update UI immediately
+                    (async () => {
+                        const html = document.documentElement;
+                        const willBeDark = !html.classList.contains("dark");
+                        await toggleTheme();
+                        html.classList.toggle("dark", willBeDark);
+                    })();
                     break;
             }
         };


### PR DESCRIPTION
Implement server-side theme management using cookies to replace client-side theme toggling.

This change ensures the theme is consistently applied from the first render, improving user experience by avoiding a flash of unstyled content (FOUC) and making the theme persistent across sessions without client-side JavaScript.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac8057ed-a904-4841-92ab-eb7dc7f1f743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac8057ed-a904-4841-92ab-eb7dc7f1f743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

